### PR TITLE
Improve photos grid layout

### DIFF
--- a/app/pages/photos.vue
+++ b/app/pages/photos.vue
@@ -18,13 +18,27 @@
               <v-btn :disabled="!canUpload" @click="uploadMany"> {{ $t("global.upload") }} </v-btn>
             </v-row>
           </div>
-          <v-row>
-            <v-col v-for="(medium, i) in media" :key="medium.id" cols="12" sm="6" md="4">
-              <v-card tile>
-                <v-img :src="createURL(medium.file)" @click="() => { openMedium(i) }">
+          <v-row class="photo-grid" dense>
+            <v-col
+              v-for="(medium, i) in media"
+              :key="medium.id"
+              cols="12"
+              sm="6"
+              md="4"
+            >
+              <v-card tile class="overflow-hidden rounded-lg" elevation="2">
+                <v-img
+                  :src="createURL(medium.file)"
+                  height="200"
+                  cover
+                  @click="() => { openMedium(i) }"
+                >
                   <template #placeholder>
                     <div class="d-flex align-center justify-center fill-height">
-                      <v-progress-circular color="grey-lighten-4" indeterminate />
+                      <v-progress-circular
+                        color="grey-lighten-4"
+                        indeterminate
+                      />
                     </div>
                   </template>
                 </v-img>
@@ -93,3 +107,10 @@ onMounted(() => {
 })
 
 </script>
+
+<style scoped>
+.photo-grid .v-img {
+  object-fit: cover;
+  height: 200px;
+}
+</style>


### PR DESCRIPTION
## Summary
- standardize the photo grid using Vuetify
- crop photos using `cover` so each item is the same height

## Testing
- `npm run lint` *(fails: Cannot find module '/workspace/photone/.nuxt/eslint.config.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_68434bcb021c832ba71f7684849ad98f