### PR TITLE
feat: highlight kafka in home tech stack

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -184,7 +184,16 @@ const categories = [
   { key: 'frameworks', icon: 'mdi-cube-outline', items: [{ key: 'spring', icon: 'mdi-language-java' }, { key: 'nuxt', icon: 'mdi-nuxt' }] },
   { key: 'security', icon: 'mdi-shield-lock', items: [{ key: 'jwt', icon: 'mdi-security' }, { key: 'bcrypt', icon: 'mdi-lock-reset' }, { key: 'roleMgmt', icon: 'mdi-account-key' }, { key: 'webCryptoApi', icon: 'mdi-web' }] },
   { key: 'languages', icon: 'mdi-code-tags', items: [{ key: 'java', icon: 'mdi-language-java' }, { key: 'typescript', icon: 'mdi-language-typescript' }] },
-  { key: 'otherBack', icon: 'mdi-server', items: [{ key: 'springDataJpa', icon: 'mdi-database' }, { key: 'lombok', icon: 'mdi-file-code' }, { key: 'awsS3', icon: 'mdi-cloud' }] },
+  {
+    key: 'otherBack',
+    icon: 'mdi-server',
+    items: [
+      { key: 'springDataJpa', icon: 'mdi-database' },
+      { key: 'lombok', icon: 'mdi-file-code' },
+      { key: 'awsS3', icon: 'mdi-cloud' },
+      { key: 'kafka', icon: 'mdi-lan' }
+    ]
+  },
   {
     key: 'otherFrontend', icon: 'mdi-web', items: [
       { key: 'pinia', icon: 'mdi-pin' },

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -106,7 +106,8 @@
         "title": "Weitere Backend-Technologien",
         "springDataJpa": "Spring Data JPA",
         "lombok": "Lombok",
-        "awsS3": "AWS S3"
+        "awsS3": "AWS S3",
+        "kafka": "Apache Kafka"
       },
       "otherFrontend": {
         "title": "Weitere Frontend-Technologien",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -107,7 +107,8 @@
       "title": "Other Backend",
       "springDataJpa": "Spring Data JPA",
       "lombok": "Lombok",
-      "awsS3": "AWS S3"
+      "awsS3": "AWS S3",
+      "kafka": "Apache Kafka"
     },
     "otherFrontend": {
       "title": "Other Frontend",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -107,7 +107,8 @@
       "title": "Backend Diverso",
       "springDataJpa": "Spring Data JPA",
       "lombok": "Lombok",
-      "awsS3": "AWS S3"
+      "awsS3": "AWS S3",
+      "kafka": "Apache Kafka"
     },
     "otherFrontend": {
       "title": "Frontend Diverso",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -108,7 +108,8 @@
       "title": "Divers Backend",
       "springDataJpa": "Spring Data JPA",
       "lombok": "Lombok",
-      "awsS3": "AWS S3"
+      "awsS3": "AWS S3",
+      "kafka": "Apache Kafka"
     },
     "otherFrontend": {
       "title": "Divers Frontend",

--- a/i18n/locales/re.json
+++ b/i18n/locales/re.json
@@ -106,7 +106,8 @@
         "title": "Lòt Zafèr Backend",
         "springDataJpa": "Spring Data JPA",
         "lombok": "Lombok",
-        "awsS3": "AWS S3"
+        "awsS3": "AWS S3",
+        "kafka": "Apache Kafka"
       },
       "otherFrontend": {
         "title": "Lòt Zafèr Frontend",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -107,7 +107,8 @@
       "title": "后端其他",
       "springDataJpa": "Spring Data JPA",
       "lombok": "Lombok",
-      "awsS3": "AWS S3"
+      "awsS3": "AWS S3",
+      "kafka": "Apache Kafka"
     },
     "otherFrontend": {
       "title": "前端其他",


### PR DESCRIPTION
## Summary
- add Kafka to the backend technology grid on the home page
- localize the new Kafka chip across all supported languages

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0345698f0832b89f030d345a0fc43